### PR TITLE
Add CDN cache refresh step to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Refresh CDN cache
         if: github.event_name == 'schedule' && github.ref == 'refs/heads/master'
         run: |
-          cd ip-lists || exit 1
-          for file in $(ls); do
+          cd ip-lists
+          for file in *; do
             curl -i "https://purge.jsdelivr.net/gh/${{ github.repository }}@ip-lists/${file}"
           done
 


### PR DESCRIPTION
部分项目使用了 jsDelivr CDN 加速（如 passwall、ssr-plus），但 jsDelivr CDN 的缓存更新太慢，因此增加一个主动刷新缓存的操作。